### PR TITLE
Feature/aaronchan32/profile backend

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:call_black_line/pages/call_text_now.dart';
 import 'package:call_black_line/pages/create_account.dart';
 import 'package:call_black_line/pages/create_affirmation.dart';
+import 'package:call_black_line/pages/profile.dart';
 import 'package:call_black_line/pages/seek_help.dart';
 
 import 'package:flutter/material.dart';
@@ -28,6 +29,7 @@ class MyApp extends StatelessWidget {
           // '/': (context) => const Profile(),
           // '/': (context) => const HaveYourVoiceHeard(),
           // '/': (context) => const CreateAffirmation(),
+          '/profile': (context) => const Profile(),
           '/callTextNow': (context) => const CallTextNow(),
           '/createAccount': (context) => const CreateAccount(),
           '/takeAction': (context) => const TakeActionPage(),

--- a/lib/pages/profile.dart
+++ b/lib/pages/profile.dart
@@ -1,17 +1,49 @@
+//Credit for fetching async data: https://www.youtube.com/watch?v=A9IN0cpPCZE
+
 import 'package:call_black_line/widgets/cbl.dart';
 import 'package:call_black_line/widgets/orange_button.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import '../widgets/custom_navbar.dart';
 import '../widgets/custom_title.dart';
 import '../widgets/header.dart';
 
-class Profile extends StatelessWidget {
+final FirebaseAuth auth = FirebaseAuth.instance;
+final CollectionReference userCollection =
+    FirebaseFirestore.instance.collection('users');
+
+class Profile extends StatefulWidget {
   const Profile({super.key});
 
   @override
+  State<Profile> createState() => _ProfileState();
+}
+
+class _ProfileState extends State<Profile> {
+  String username = '';
+  String email = auth.currentUser?.email ?? '';
+  Future _getFireStoreUser() async {
+    userCollection
+        .doc(auth.currentUser?.uid)
+        .get()
+        .then((DocumentSnapshot snapshot) async {
+      if (snapshot.exists) {
+        setState(() {
+          username = snapshot["username"];
+        });
+      }
+    });
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _getFireStoreUser();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    const username = 'John Doe';
-    const email = 'johndoe@example.com';
     return Scaffold(
       resizeToAvoidBottomInset: false,
       backgroundColor: Colors.white,
@@ -77,14 +109,17 @@ class Profile extends StatelessWidget {
               ],
             ),
             const Spacer(),
-            const Padding(
-              padding: EdgeInsets.only(bottom: 50),
+            Padding(
+              padding: const EdgeInsets.only(bottom: 50),
               child: OrangeButton(
-                buttonText: 'Logout',
-                width: 146,
-                // onTap: () => setState(() => subscribed = true),
-              ),
-            )
+                  buttonText: 'Logout',
+                  width: 146,
+                  onTap: () async {
+                    // context.read<AuthenticationService>().signOut();
+                    await auth.signOut();
+                    Navigator.pushNamed(context, '/seekHelp');
+                  }),
+            ),
           ],
         ),
       ),

--- a/lib/widgets/custom_navbar.dart
+++ b/lib/widgets/custom_navbar.dart
@@ -1,5 +1,8 @@
 import 'package:call_black_line/widgets/cbl.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+
+final FirebaseAuth auth = FirebaseAuth.instance;
 
 class CustomNavBar extends StatelessWidget {
   final String currentPage;
@@ -45,7 +48,10 @@ class CustomNavBar extends StatelessWidget {
                 icon: Icons.person,
                 isCurrentPage: currentPage == 'Profile',
                 onPressed: () => {
-                  // Navigator.pushNamed(context, '/profile')
+                  if (auth.currentUser == null)
+                    {Navigator.pushNamed(context, '/takeAction')}
+                  else
+                    {Navigator.pushNamed(context, '/profile')}
                 },
               ),
             ],


### PR DESCRIPTION
### Tracking Info

Resolves #31

### Changes

- Asynchronously fetch username data from firestore based user's UID
- Add functioning sign-out button
- Redirect unauthenticated user to TakeAction page if they try to access profile page from navbar

### Testing

- Requires change made from Routing auth #29 
- Please merge the changes from above for everything to work. Unless future changes to profile.dart are made in issue 29, accept current changes for profile.dart when merging.

### Confirmation of Change 

<img width="196" alt="image" src="https://user-images.githubusercontent.com/42254254/235543890-cc063d9f-4d11-4322-b3ee-781a71bfba55.png">

- Demonstrating protected route and username fetch

https://user-images.githubusercontent.com/42254254/235544058-4ebd54d4-f41c-48d2-9626-1b1e0786b953.mp4

