### PR TITLE
Feature/willji0023/affirmations backend

### DIFF
--- a/lib/affirmation.dart
+++ b/lib/affirmation.dart
@@ -16,7 +16,7 @@ class Affirmation {
 }
 
 class AffirmationWithUsername {
-  final String text;
+  String text;
   final String username;
   final int created;
 

--- a/lib/affirmation.dart
+++ b/lib/affirmation.dart
@@ -1,0 +1,68 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'dart:developer' as developer;
+
+import 'package:call_black_line/user.dart';
+
+class Affirmation {
+  final String text;
+  final String uid;
+  final int created;
+
+  Affirmation({required this.text, required this.uid, required this.created});
+
+  Map<String, dynamic> toMap() {
+    return {'text': text, 'uid': uid, 'created': created};
+  }
+}
+
+class AffirmationWithUsername {
+  final String text;
+  final String username;
+  final int created;
+
+  AffirmationWithUsername(
+      {required this.text, this.username = "", required this.created});
+}
+
+class AffirmationRepository {
+  final CollectionReference affirmations =
+      FirebaseFirestore.instance.collection('affirmations');
+
+  Future<Object> addAffirmation(Affirmation affirmation) async {
+    try {
+      developer.log(affirmation.toMap().toString());
+      return await affirmations.add(affirmation.toMap());
+    } catch (e) {
+      return {'status': 'ERROR', 'message': e.toString()};
+    }
+  }
+
+  /// Gets a list of all affirmations stored in the backend, and looks up the
+  /// Users corresponding to each stored uid to obtain the username of the
+  /// affirmation's creator
+  Future<List<AffirmationWithUsername>> getAffirmationList() async {
+    QuerySnapshot qShot = await affirmations.get();
+    UserRepository users = UserRepository();
+
+    List<AffirmationWithUsername> affirmationsWithUsernames = [];
+    for (DocumentSnapshot doc in qShot.docs) {
+      String uid = doc['uid'];
+      String username;
+      // Catch the cases where the user id is "" (which is currently the case
+      // until login is finished) or the User of the uid is not found.
+      try {
+        DocumentSnapshot userDoc = await users.getUser(uid);
+        username = userDoc.get("username");
+      } catch (e) {
+        username = "Unknown";
+      }
+      AffirmationWithUsername affirmation = AffirmationWithUsername(
+        text: doc['text'],
+        username: username,
+        created: doc['created'],
+      );
+      affirmationsWithUsernames.add(affirmation);
+    }
+    return affirmationsWithUsernames;
+  }
+}

--- a/lib/datatest/main.dart
+++ b/lib/datatest/main.dart
@@ -1,7 +1,9 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import '../user.dart';
 import 'package:firebase_core/firebase_core.dart';
 import '../testimonial.dart';
+import '../affirmation.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -96,7 +98,8 @@ class _MyHomePageState extends State<MyHomePage> {
                 onPressed: () {
                   //test 10 times
                   UserRepository userRepository = UserRepository();
-                  User user = User(username: 'John Doe',
+                  User user = User(
+                      username: 'John Doe',
                       phoneNumber: 8583165432,
                       email: 'johndoe@example.com');
 
@@ -165,7 +168,34 @@ class _MyHomePageState extends State<MyHomePage> {
                   submitTestimonial.deleteTestimonial("UUzkdbXVUXmVZwAtBbEr");
                   submitTestimonial.deleteTestimonial("doesn't exist");
                 },
-                child: const Text('Delete Testimonial'))
+                child: const Text('Delete Testimonial')),
+            ElevatedButton(
+                onPressed: () async {
+                  AffirmationRepository affirmations = AffirmationRepository();
+                  Affirmation affirmationWithRealId1 = Affirmation(
+                      created: DateTime.now().millisecondsSinceEpoch,
+                      uid: "0p4AgrUHXJnLtCe4owG6",
+                      text: "Test Text 1");
+                  Affirmation affirmationWithRealId2 = Affirmation(
+                      created: DateTime.now().millisecondsSinceEpoch,
+                      uid: "B4Ww1lg1o9i5J1TYxvJ9",
+                      text: "Test Text 2");
+                  Affirmation affirmationWithEmptyId = Affirmation(
+                      created: DateTime.now().millisecondsSinceEpoch,
+                      uid: "",
+                      text: "Test Text 3");
+                  Affirmation affirmationWithFakeId = Affirmation(
+                      created: DateTime.now().millisecondsSinceEpoch,
+                      uid: "ThisIdDoesntExist",
+                      text: "Test Text 4");
+                  affirmations.addAffirmation(affirmationWithRealId1);
+                  affirmations.addAffirmation(affirmationWithRealId2);
+                  affirmations.addAffirmation(affirmationWithEmptyId);
+                  affirmations.addAffirmation(affirmationWithFakeId);
+                  var al = await affirmations.getAffirmationList();
+                  assert(al.length >= 4);
+                },
+                child: const Text('Create Affirmation')),
           ],
         ),
       ), // This trailing comma makes auto-formatting nicer for build methods.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,8 +5,11 @@ import 'package:call_black_line/pages/seek_help.dart';
 
 import 'package:flutter/material.dart';
 import 'package:call_black_line/pages/take_action.dart';
+import 'package:firebase_core/firebase_core.dart';
 
-void main() {
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp();
   runApp(const MyApp());
 }
 
@@ -23,11 +26,11 @@ class MyApp extends StatelessWidget {
           ),
         ),
         routes: {
-          '/': (context) => const SeekHelp(),
+          // '/': (context) => const SeekHelp(),
           // '/': (context) => const Donation(),
           // '/': (context) => const Profile(),
           // '/': (context) => const HaveYourVoiceHeard(),
-          // '/': (context) => const CreateAffirmation(),
+          '/': (context) => const CreateAffirmation(),
           '/callTextNow': (context) => const CallTextNow(),
           '/createAccount': (context) => const CreateAccount(),
           '/takeAction': (context) => const TakeActionPage(),

--- a/lib/pages/affirmation_sent.dart
+++ b/lib/pages/affirmation_sent.dart
@@ -11,7 +11,7 @@ class AffirmationSent extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: Colors.white,
-      appBar: const Header(),
+      appBar: const Header(isHome: true),
       bottomNavigationBar: const CustomNavBar(
         currentPage: 'Resources',
       ),

--- a/lib/pages/create_new_affirmation.dart
+++ b/lib/pages/create_new_affirmation.dart
@@ -1,13 +1,31 @@
 import 'package:call_black_line/widgets/orange_button.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:call_black_line/widgets/custom_title.dart';
 import 'package:call_black_line/widgets/header.dart';
 import 'package:call_black_line/widgets/custom_navbar.dart';
 import 'package:call_black_line/widgets/text_area.dart';
 import 'package:call_black_line/pages/affirmation_sent.dart';
+import 'package:call_black_line/affirmation.dart';
 
-class CreateNewAffirmation extends StatelessWidget {
+final FirebaseAuth auth = FirebaseAuth.instance;
+
+class CreateNewAffirmation extends StatefulWidget {
   const CreateNewAffirmation({super.key});
+
+  @override
+  State<CreateNewAffirmation> createState() => _CreateNewAffirmation();
+}
+
+class _CreateNewAffirmation extends State<CreateNewAffirmation> {
+  final textAreaController = TextEditingController();
+
+  @override
+  void dispose() {
+    // Clean up the controller when the widget is disposed.
+    textAreaController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -38,7 +56,8 @@ class CreateNewAffirmation extends StatelessWidget {
             const SizedBox(
               height: 48,
             ),
-            const TextArea(hintText: "Type something"),
+            TextArea(
+                hintText: "Type something", controller: textAreaController),
             const SizedBox(
               height: 90,
             ),
@@ -48,6 +67,13 @@ class CreateNewAffirmation extends StatelessWidget {
                   buttonText: 'Submit',
                   width: 110,
                   onTap: () {
+                    AffirmationRepository affirmationRepository =
+                        AffirmationRepository();
+                    Affirmation affirmation = Affirmation(
+                        text: textAreaController.text,
+                        uid: auth.currentUser?.uid ?? '',
+                        created: DateTime.now().millisecondsSinceEpoch);
+                    affirmationRepository.addAffirmation(affirmation);
                     Navigator.push(
                         context,
                         MaterialPageRoute(

--- a/lib/pages/use_preexisting_affirmation.dart
+++ b/lib/pages/use_preexisting_affirmation.dart
@@ -40,6 +40,7 @@ class _UsePreexistingAffirmationState extends State<UsePreexistingAffirmation> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      resizeToAvoidBottomInset: false,
       backgroundColor: Colors.white,
       appBar: const Header(),
       bottomNavigationBar: const CustomNavBar(

--- a/lib/pages/use_preexisting_affirmation.dart
+++ b/lib/pages/use_preexisting_affirmation.dart
@@ -7,7 +7,7 @@ import 'package:call_black_line/widgets/custom_title.dart';
 import 'package:call_black_line/widgets/header.dart';
 import 'package:call_black_line/widgets/custom_navbar.dart';
 import 'package:call_black_line/pages/affirmation_sent.dart';
-import 'package:drop_cap_text/drop_cap_text.dart';
+import "package:drop_cap_text/drop_cap_text.dart";
 import 'package:call_black_line/affirmation.dart';
 
 final FirebaseAuth auth = FirebaseAuth.instance;
@@ -104,8 +104,65 @@ class _UsePreexistingAffirmationState extends State<UsePreexistingAffirmation> {
                                             dropCap: DropCap(
                                                 width: 25,
                                                 height: 25,
-                                                child: Image.asset(
-                                                    'assets/images/edit.png'))),
+                                                child: IconButton(
+                                                  padding:
+                                                      const EdgeInsets.all(0),
+                                                  icon: Image.asset(
+                                                      'assets/images/edit.png'),
+                                                  onPressed: () {
+                                                    showDialog(
+                                                      context: context,
+                                                      builder: (context) {
+                                                        TextEditingController
+                                                            controller =
+                                                            TextEditingController(
+                                                                text: affirmations[
+                                                                        index]
+                                                                    .text);
+                                                        return AlertDialog(
+                                                          title: const Text(
+                                                              "Edit Affirmation"),
+                                                          content: TextField(
+                                                            controller:
+                                                                controller,
+                                                            decoration:
+                                                                const InputDecoration(
+                                                              hintText:
+                                                                  "Enter new text here",
+                                                            ),
+                                                          ),
+                                                          actions: <Widget>[
+                                                            TextButton(
+                                                              child: const Text(
+                                                                  "Cancel"),
+                                                              onPressed: () {
+                                                                Navigator.of(
+                                                                        context)
+                                                                    .pop();
+                                                              },
+                                                            ),
+                                                            TextButton(
+                                                              child: const Text(
+                                                                  "Save"),
+                                                              onPressed: () {
+                                                                setState(() {
+                                                                  affirmations[
+                                                                              index]
+                                                                          .text =
+                                                                      controller
+                                                                          .text;
+                                                                });
+                                                                Navigator.of(
+                                                                        context)
+                                                                    .pop();
+                                                              },
+                                                            ),
+                                                          ],
+                                                        );
+                                                      },
+                                                    );
+                                                  },
+                                                ))),
                                         const SizedBox(
                                           height: 12,
                                         ),

--- a/lib/pages/use_preexisting_affirmation.dart
+++ b/lib/pages/use_preexisting_affirmation.dart
@@ -1,16 +1,16 @@
+import 'dart:developer';
+
 import 'package:call_black_line/widgets/orange_button.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:call_black_line/widgets/custom_title.dart';
 import 'package:call_black_line/widgets/header.dart';
 import 'package:call_black_line/widgets/custom_navbar.dart';
 import 'package:call_black_line/pages/affirmation_sent.dart';
 import 'package:drop_cap_text/drop_cap_text.dart';
+import 'package:call_black_line/affirmation.dart';
 
-final List<Map<String, String>> dummyEntries = List.filled(7, {
-  'text':
-      'Lorem ipsum dolor sit amet consectetur. Molestie neque faucibus viverra ut nisl nec eleifend.',
-  'author': 'Jane Smith',
-}); // TODO: connect with backend
+final FirebaseAuth auth = FirebaseAuth.instance;
 
 class UsePreexistingAffirmation extends StatefulWidget {
   const UsePreexistingAffirmation({super.key});
@@ -21,7 +21,21 @@ class UsePreexistingAffirmation extends StatefulWidget {
 }
 
 class _UsePreexistingAffirmationState extends State<UsePreexistingAffirmation> {
+  late List<AffirmationWithUsername> affirmations = [];
   int selectedIndex = -1;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadData();
+  }
+
+  Future<void> _loadData() async {
+    final affirmationRepository = AffirmationRepository();
+    affirmations = await affirmationRepository.getAffirmationList();
+    log('Loaded list of affirmations of length: ${affirmations.length}');
+    setState(() {});
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -55,7 +69,7 @@ class _UsePreexistingAffirmationState extends State<UsePreexistingAffirmation> {
                     height: 380,
                     width: 400,
                     child: ListView.separated(
-                        itemCount: dummyEntries.length,
+                        itemCount: affirmations.length,
                         separatorBuilder: (context, index) {
                           return const SizedBox(height: 16);
                         },
@@ -78,8 +92,7 @@ class _UsePreexistingAffirmationState extends State<UsePreexistingAffirmation> {
                                       padding: const EdgeInsets.symmetric(
                                           horizontal: 15.0, vertical: 10.0),
                                       child: Column(children: [
-                                        DropCapText(
-                                            dummyEntries[index]['text']!,
+                                        DropCapText(affirmations[index].text,
                                             style: TextStyle(
                                                 color: selectedIndex == index
                                                     ? Colors.white
@@ -99,7 +112,7 @@ class _UsePreexistingAffirmationState extends State<UsePreexistingAffirmation> {
                                         Align(
                                             alignment: Alignment.centerLeft,
                                             child: Text(
-                                              'By: ${dummyEntries[index]['author']}',
+                                              'By: ${affirmations[index].username}',
                                               style: TextStyle(
                                                 fontSize: 18,
                                                 color: selectedIndex == index
@@ -116,7 +129,13 @@ class _UsePreexistingAffirmationState extends State<UsePreexistingAffirmation> {
                   buttonText: 'Submit',
                   width: 110,
                   onTap: () {
-                    // TODO: Check if index is valid, and if so submit from list of Affirmationss
+                    AffirmationRepository affirmationRepository =
+                        AffirmationRepository();
+                    Affirmation affirmation = Affirmation(
+                        text: affirmations[selectedIndex].text,
+                        uid: auth.currentUser?.uid ?? '',
+                        created: DateTime.now().millisecondsSinceEpoch);
+                    affirmationRepository.addAffirmation(affirmation);
                     Navigator.push(
                         context,
                         MaterialPageRoute(

--- a/lib/user.dart
+++ b/lib/user.dart
@@ -5,16 +5,11 @@ class User {
   final int phoneNumber;
   final String email;
 
-  User({required this.username,
-      required this.phoneNumber,
-      required this.email});
+  User(
+      {required this.username, required this.phoneNumber, required this.email});
 
   Map<String, dynamic> toMap() {
-    return {
-      'username': username,
-      'phoneNumber': phoneNumber,
-      'email': email
-    };
+    return {'username': username, 'phoneNumber': phoneNumber, 'email': email};
   }
 }
 
@@ -33,6 +28,14 @@ class UserRepository {
   Future<void> deleteUser(String id) async {
     try {
       return await userCollection.doc(id).delete();
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  Future<DocumentSnapshot> getUser(String id) async {
+    try {
+      return await userCollection.doc(id).get();
     } catch (e) {
       rethrow;
     }

--- a/lib/widgets/text_area.dart
+++ b/lib/widgets/text_area.dart
@@ -6,18 +6,20 @@ class TextArea extends StatelessWidget {
   final String hintText;
   final Color enabledBorderColor;
   final Color focusedBorderColor;
-  const TextArea({
-    super.key,
-    this.maxLines = 3,
-    this.textColor = Colors.black,
-    this.hintText = "",
-    this.enabledBorderColor = Colors.grey,
-    this.focusedBorderColor = Colors.grey,
-  });
+  final TextEditingController controller;
+  const TextArea(
+      {super.key,
+      this.maxLines = 3,
+      this.textColor = Colors.black,
+      this.hintText = "",
+      this.enabledBorderColor = Colors.grey,
+      this.focusedBorderColor = Colors.grey,
+      required this.controller});
 
   @override
   Widget build(BuildContext context) {
     return TextField(
+        controller: controller,
         style: TextStyle(color: textColor),
         keyboardType: TextInputType.multiline,
         maxLines: maxLines,


### PR DESCRIPTION
### Tracking Info

Resolves #33 

### Changes

- Created `affirmation.dart` for creating and getting Affirmations to and from Cloud Firestore.
  - Affirmations are being stored with `created`, `text`, and `uid` (user id). Upon loading the `create_new_affirmation` page, we get all the affirmations stored in the backend and lookup usernames (to display on the page) in the User collection using the `uid`. Added `getUser` in `user.dart` to aid with this.
- Connected these hooks to the `use_preexisting_affirmation` and `create_new_affirmation` pages. 
- The edit button on the `use_preexisting_affirmation` now does something
  - Opens a popup to allow the user to edit the pre-existing  affirmation if they want to. I couldn't find any Figma designs for this, so it is very basic for now.
- Added Affirmation backend testing to the `datatest/main.dart`

### Testing

- Assert in `datatest/main.dart` checks that affirmations were successfully added and retrieved from Cloud Firestore.
- Manually tested the `create_new_affirmation` and `use_preexisting_affirmation`  workflow, which successfully creates a new affirmation in the backend
  - Currently `auth.currentUser?.uid` is null, so `uid` is set to "". 
- Manually tested the edit button on the `use_preexisting_affirmation` page.

### Confirmation of Change 

https://user-images.githubusercontent.com/23545972/235858803-8cf4ac6e-b903-4bcc-8b82-137fd1d7a4b6.mp4